### PR TITLE
Use latest version of test doubles library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "mockery/mockery": "^1.0",
         "phpunit/phpunit": "^7.0",
         "squizlabs/php_codesniffer": "^3.2",
-        "wmde/psr-log-test-doubles": "^2.2"
+        "jeroen/psr-log-test-doubles": "^2.2|^3.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true


### PR DESCRIPTION
This allows installation together with psr/log 3.x, rather than restricting
to only psr/log 1.x.

psr/log 3.x is already supported by other dependencies, ie
https://packagist.org/packages/enqueue/enqueue,
so psr-log-test-doubles is the holdup.

jeroen/psr-log-test-doubles is where I maintain the library nowadays.